### PR TITLE
remove duplicates requires-python in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "numpy>=1.23",
     "opencv-python>=4.8",
 ] 
-requires-python = ">=3.11" 
+
 authors = [ 
 {name = "Mithra", email = "mithrabijumon@gmail.com"}, 
 ] 


### PR DESCRIPTION
Remove duplicate requires-python entry from pyproject.toml.  The duplicate key was causing TOML parsing errors during package installation.