### PR TITLE
fix: remove duplicate Python version entries in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "numpy>=1.23",
     "opencv-python>=4.8",
 ] 
-requires-python = ">=3.11" 
 authors = [ 
 {name = "Mithra", email = "mithrabijumon@gmail.com"}, 
 ] 


### PR DESCRIPTION
Fixed duplicate Python version specifications in pyproject.toml as it was causing error during installation .